### PR TITLE
Add issue template for new l10n initiation

### DIFF
--- a/.github/ISSUE_TEMPLATE/l10n-initiation.md
+++ b/.github/ISSUE_TEMPLATE/l10n-initiation.md
@@ -1,0 +1,39 @@
+---
+name: Initiate a New Localization Team
+about: Issue to inform the initiation of localization for a new language to cncf/glossary
+labels:
+- enhancement
+---
+
+# This issue is to initiate a new l10n Team
+
+Please only use this template for submitting a new l10n team initiation requests. 
+
+See https://github.com/cncf/glossary/blob/main/LOCALIZATION.md for basic requirements for a new l10n team.
+
+---
+
+### (1) The language and language code for l10n
+Find localization's two-letter language code from [ISO 639-1 standard](https://www.loc.gov/standards/iso639-2/php/code_list.php).
+
+For example, the two-letter code for Korean is `ko`.
+
+ - Language name (ex: `Korean`): 
+ - Language two-letter code (ex: `ko`): 
+
+
+### (2) List of volunteers
+Name and GitHub Username for each l10n volunteer. Add `[A]` to make them approvers.
+
+Ex: `- [A] Seokho Son (@seokho-son)`
+
+- 
+- 
+- 
+
+---
+### (Note) Next actions from maintainers
+
+ - Create a new development branch for the l10n. (ex: `dev-ko`)
+ - Update codeowners to add l10n contents approvers.
+ - Add a new label for the language.


### PR DESCRIPTION
This issue template includes 

- Information for language and language code for l10n
- List of volunteers
- Next actions from maintainers
